### PR TITLE
Filter nested documents when using custom mapping

### DIFF
--- a/lib/searchkick/query.rb
+++ b/lib/searchkick/query.rb
@@ -891,6 +891,12 @@ module Searchkick
           filters << {bool: {must_not: where_filters(value)}}
         elsif field == :_and
           filters << {bool: {must: value.map { |or_statement| {bool: {filter: where_filters(or_statement)}} }}}
+        elsif field == :nested
+          Array.wrap(value).each do |nested_filter|
+            if nested_filter[:path].present? && nested_filter[:where].present?
+              filters << {field => nested_filter.except(:where).merge(query: {bool: {filter: nested_filter[:where].map { |f, v| term_filters(f, v) }}})}
+            end
+          end
         # elsif field == :_script
         #   filters << {script: {script: {source: value, lang: "painless"}}}
         else


### PR DESCRIPTION
Usage:
```ruby
class Product < ApplicationRecord
  searchkick mappings: {
    properties: {
      variants: {type: "nested", properties: {...}}
    }
  }
end
```

Search:
```ruby
Product.search("*", where: {nested: [{
  path: "variants",
  inner_hits: {},
  where: {
    "variants.store_id": params[:store_id],
    "variants.status": "listed",
  }
}]})
```

Resulting query:
```json
{
  "query": {
    "bool": {
      "must": {"match_all": {}},
      "filter": [
        {
          "nested": {
            "path": "variants",
            "inner_hits": {},
            "query": {
              "bool": {
                "filter": [
                  {"term": {"variants.store_id": {"value": "123"}}},
                  {"term": {"variants.status": {"value": "listed"}}}
                ]
              }
            }
          }
        }
      ]
    }
  }
}
```